### PR TITLE
Fix point lat/lng order

### DIFF
--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -62,7 +62,7 @@ class Point extends Geometry
 
     public function __toString()
     {
-        return $this->getLng().' '.$this->getLat();
+        return $this->getLat().' '.$this->getLng();
     }
 
     /**


### PR DESCRIPTION
While working on a project incorporating this library I ran into the issue that points are always saved backwards.

Through some debugging I could pinpoint this to `Point::__toString()`. This method is also used to build the WKT strings, where the format has to be `POINT(lat lng)`.

EDIT: Using MariaDB. Maybe that is the fault here? Will investigate further.