### PR TITLE
Multipolygon WKT Parsing Bugfix

### DIFF
--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -45,7 +45,7 @@ class Point extends Geometry
 
     public static function fromPair($pair)
     {
-        list($lng, $lat) = explode(' ', trim($pair));
+        list($lng, $lat) = explode(' ', trim($pair, "\t\n\r \x0B()"));
 
         return new static((float) $lat, (float) $lng);
     }

--- a/tests/Unit/Types/MultiPolygonTest.php
+++ b/tests/Unit/Types/MultiPolygonTest.php
@@ -13,6 +13,13 @@ class MultiPolygonTest extends BaseTestCase
         $this->assertInstanceOf(MultiPolygon::class, $polygon);
 
         $this->assertEquals(2, $polygon->count());
+
+        $polygon = MultiPolygon::fromWKT('MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))');
+        $this->assertInstanceOf(MultiPolygon::class, $polygon);
+
+        $this->assertEquals(2, $polygon->count());
+
+        $this->assertEquals('MULTIPOLYGON(((30 20,45 40,10 40,30 20)),((15 5,40 10,10 20,5 10,15 5)))', $polygon->toWKT());
     }
 
     public function testToWKT()


### PR DESCRIPTION
## Changes
- fixes bug where leading a leading `(` passed to `Types\Point::fromPair($pair)` would result in the longitude being incorrectly cast to `0.0`, which was breaking multipolygon parsing from WKT