### PR TITLE
Fix validation when creating GeometryCollections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
   - docker
 
 before_install:
-  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=3G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - sudo /etc/init.d/mysql stop
   - make start_db V=$MYSQL_VERSION
 

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.5.9",
         "ext-pdo": "*",
         "ext-json": "*",
-        "illuminate/database": "^5.2|^6.0",
+        "illuminate/database": "^5.2||^6.0",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8||~5.7",
         "mockery/mockery": "^0.9.9",
-        "laravel/laravel": "^5.2|^6.0",
+        "laravel/laravel": "^5.2||^6.0",
         "doctrine/dbal": "^2.5",
         "laravel/browser-kit-testing": "^2.0",
         "php-coveralls/php-coveralls": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8||~5.7",
+        "phpunit/phpunit": "~4.8|~5.7",
         "mockery/mockery": "^0.9.9",
         "laravel/laravel": "^5.2|^6.0|^7.0",
         "doctrine/dbal": "^2.5",

--- a/src/Types/GeometryCollection.php
+++ b/src/Types/GeometryCollection.php
@@ -150,7 +150,7 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
     }
 
     /**
-     * Checks.
+     * Checks whether the items are valid to create this collection.
      *
      * @param array $items
      */
@@ -163,6 +163,13 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
         }
     }
 
+    /**
+     * Checks whether the array has enough items to generate a valid WKT.
+     *
+     * @param array $items
+     *
+     * @see $minimumCollectionItems
+     */
     protected function validateItemCount(array $items)
     {
         if (count($items) < $this->minimumCollectionItems) {
@@ -174,6 +181,13 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
         }
     }
 
+    /**
+     * Checks the type of the items in the array.
+     *
+     * @param $item
+     *
+     * @see $collectionItemType
+     */
     protected function validateItemType($item)
     {
         if (!$item instanceof $this->collectionItemType) {

--- a/src/Types/GeometryCollection.php
+++ b/src/Types/GeometryCollection.php
@@ -19,7 +19,7 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
      *
      * @var int
      */
-    protected $minimumCollectionItems = 1;
+    protected $minimumCollectionItems = 0;
 
     /**
      * The class of the items in the collection.
@@ -66,6 +66,10 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
 
     public static function fromString($wktArgument)
     {
+        if (empty($wktArgument)) {
+            return new static([]);
+        }
+
         $geometry_strings = preg_split('/,\s*(?=[A-Za-z])/', $wktArgument);
 
         return new static(array_map(function ($geometry_string) {

--- a/src/Types/LineString.php
+++ b/src/Types/LineString.php
@@ -8,6 +8,13 @@ use Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException;
 
 class LineString extends PointCollection
 {
+    /**
+     * The minimum number of items required to create this collection.
+     *
+     * @var int
+     */
+    protected $minimumCollectionItems = 2;
+
     public function toWKT()
     {
         return sprintf('LINESTRING(%s)', $this->toPairList());

--- a/src/Types/MultiLineString.php
+++ b/src/Types/MultiLineString.php
@@ -10,24 +10,18 @@ use InvalidArgumentException;
 class MultiLineString extends GeometryCollection
 {
     /**
-     * @param LineString[] $lineStrings
+     * The minimum number of items required to create this collection.
+     *
+     * @var int
      */
-    public function __construct(array $lineStrings)
-    {
-        if (count($lineStrings) < 1) {
-            throw new InvalidArgumentException('$lineStrings must contain at least one entry');
-        }
+    protected $minimumCollectionItems = 1;
 
-        $validated = array_filter($lineStrings, function ($value) {
-            return $value instanceof LineString;
-        });
-
-        if (count($lineStrings) !== count($validated)) {
-            throw new InvalidArgumentException('$lineStrings must be an array of LineString');
-        }
-
-        parent::__construct($lineStrings);
-    }
+    /**
+     * The class of the items in the collection.
+     *
+     * @var string
+     */
+    protected $collectionItemType = LineString::class;
 
     public function getLineStrings()
     {
@@ -58,9 +52,7 @@ class MultiLineString extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        if (!($value instanceof LineString)) {
-            throw new InvalidArgumentException('$value must be an instance of LineString');
-        }
+        $this::validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/src/Types/MultiLineString.php
+++ b/src/Types/MultiLineString.php
@@ -44,7 +44,7 @@ class MultiLineString extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        $this::validateItemType($value);
+        $this->validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/src/Types/MultiLineString.php
+++ b/src/Types/MultiLineString.php
@@ -9,6 +9,13 @@ use Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException;
 class MultiLineString extends GeometryCollection
 {
     /**
+     * The minimum number of items required to create this collection.
+     *
+     * @var int
+     */
+    protected $minimumCollectionItems = 1;
+
+    /**
      * The class of the items in the collection.
      *
      * @var string

--- a/src/Types/MultiLineString.php
+++ b/src/Types/MultiLineString.php
@@ -9,13 +9,6 @@ use Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException;
 class MultiLineString extends GeometryCollection
 {
     /**
-     * The minimum number of items required to create this collection.
-     *
-     * @var int
-     */
-    protected $minimumCollectionItems = 1;
-
-    /**
      * The class of the items in the collection.
      *
      * @var string

--- a/src/Types/MultiPoint.php
+++ b/src/Types/MultiPoint.php
@@ -8,6 +8,13 @@ use Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException;
 
 class MultiPoint extends PointCollection
 {
+    /**
+     * The minimum number of items required to create this collection.
+     *
+     * @var int
+     */
+    protected $minimumCollectionItems = 1;
+
     public function toWKT()
     {
         return sprintf('MULTIPOINT(%s)', (string) $this);

--- a/src/Types/MultiPolygon.php
+++ b/src/Types/MultiPolygon.php
@@ -91,7 +91,7 @@ class MultiPolygon extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        self::validateItemType($value);
+        $this->validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/src/Types/MultiPolygon.php
+++ b/src/Types/MultiPolygon.php
@@ -13,7 +13,7 @@ class MultiPolygon extends GeometryCollection
      *
      * @var int
      */
-    protected $minimumCollectionItems = 0;
+    protected $minimumCollectionItems = 1;
 
     /**
      * The class of the items in the collection.

--- a/src/Types/MultiPolygon.php
+++ b/src/Types/MultiPolygon.php
@@ -10,19 +10,18 @@ use InvalidArgumentException;
 class MultiPolygon extends GeometryCollection
 {
     /**
-     * @param Polygon[] $polygons
+     * The minimum number of items required to create this collection.
+     *
+     * @var int
      */
-    public function __construct(array $polygons)
-    {
-        $validated = array_filter($polygons, function ($value) {
-            return $value instanceof Polygon;
-        });
+    protected $minimumCollectionItems = 0;
 
-        if (count($polygons) !== count($validated)) {
-            throw new InvalidArgumentException('$polygons must be an array of Polygon');
-        }
-        parent::__construct($polygons);
-    }
+    /**
+     * The class of the items in the collection.
+     *
+     * @var string
+     */
+    protected $collectionItemType = Polygon::class;
 
     public function toWKT()
     {
@@ -93,9 +92,7 @@ class MultiPolygon extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        if (!($value instanceof Polygon)) {
-            throw new InvalidArgumentException('$value must be an instance of Polygon');
-        }
+        self::validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/src/Types/PointCollection.php
+++ b/src/Types/PointCollection.php
@@ -8,24 +8,11 @@ use InvalidArgumentException;
 abstract class PointCollection extends GeometryCollection
 {
     /**
-     * @param Point[] $points
+     * The class of the items in the collection.
+     *
+     * @var string
      */
-    public function __construct(array $points)
-    {
-        if (count($points) < 2) {
-            throw new InvalidArgumentException('$points must contain at least two entries');
-        }
-
-        $validated = array_filter($points, function ($value) {
-            return $value instanceof Point;
-        });
-
-        if (count($points) !== count($validated)) {
-            throw new InvalidArgumentException('$points must be an array of Points');
-        }
-
-        parent::__construct($points);
-    }
+    protected $collectionItemType = Point::class;
 
     public function toPairList()
     {
@@ -36,9 +23,7 @@ abstract class PointCollection extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        if (!($value instanceof Point)) {
-            throw new InvalidArgumentException('$value must be an instance of Point');
-        }
+        self::validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/src/Types/PointCollection.php
+++ b/src/Types/PointCollection.php
@@ -23,7 +23,7 @@ abstract class PointCollection extends GeometryCollection
 
     public function offsetSet($offset, $value)
     {
-        self::validateItemType($value);
+        $this->validateItemType($value);
 
         parent::offsetSet($offset, $value);
     }

--- a/tests/Integration/SpatialTest.php
+++ b/tests/Integration/SpatialTest.php
@@ -242,6 +242,17 @@ class SpatialTest extends BaseTestCase
         $this->assertDatabaseHas('geometry', ['id' => $geo->id]);
     }
 
+    public function testInsertEmptyGeometryCollection()
+    {
+        $geo = new GeometryModel();
+
+        $geo->location = new Point(1, 2);
+
+        $geo->multi_geometries = new GeometryCollection([]);
+        $geo->save();
+        $this->assertDatabaseHas('geometry', ['id' => $geo->id]);
+    }
+
     public function testUpdate()
     {
         $geo = new GeometryModel();

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -7,7 +7,7 @@ abstract class BaseTestCase extends PHPUnit_Framework_TestCase
         Mockery::close();
     }
 
-    protected function assertException($exceptionName, $exceptionMessage = 'uoioi', $exceptionCode = 0)
+    protected function assertException($exceptionName, $exceptionMessage = '', $exceptionCode = 0)
     {
         if (method_exists(parent::class, 'expectException')) {
             parent::expectException($exceptionName);

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -7,12 +7,14 @@ abstract class BaseTestCase extends PHPUnit_Framework_TestCase
         Mockery::close();
     }
 
-    protected function assertException($exceptionName)
+    protected function assertException($exceptionName, $exceptionMessage = 'uoioi', $exceptionCode = 0)
     {
         if (method_exists(parent::class, 'expectException')) {
             parent::expectException($exceptionName);
+            parent::expectExceptionMessage($exceptionMessage);
+            parent::expectExceptionCode($exceptionCode);
         } else {
-            $this->setExpectedException($exceptionName);
+            $this->setExpectedException($exceptionName, $exceptionMessage, $exceptionCode);
         }
     }
 }

--- a/tests/Unit/Eloquent/SpatialTraitTest.php
+++ b/tests/Unit/Eloquent/SpatialTraitTest.php
@@ -484,7 +484,10 @@ class SpatialTraitTest extends BaseTestCase
     public function testScopeOrderBySpatialThrowsExceptionWhenFunctionNotRegistered()
     {
         $point = new Point(1, 2);
-        $this->assertException(\Grimzy\LaravelMysqlSpatial\Exceptions\UnknownSpatialFunctionException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\UnknownSpatialFunctionException::class,
+            'does-not-exist'
+        );
         TestModel::orderBySpatial('point', $point, 'does-not-exist');
     }
 

--- a/tests/Unit/Types/GeometryCollectionTest.php
+++ b/tests/Unit/Types/GeometryCollectionTest.php
@@ -33,6 +33,28 @@ class GeometryCollectionTest extends BaseTestCase
         $this->assertSame('{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[0,0],[1,0],[1,1],[0,1],[0,0]]},{"type":"Point","coordinates":[200,100]}]}', json_encode($this->getGeometryCollection()->jsonSerialize()));
     }
 
+    public function testCanCreateEmptyGeometryCollection()
+    {
+        $geometryCollection = new GeometryCollection([]);
+        $this->assertInstanceOf(GeometryCollection::class, $geometryCollection);
+    }
+
+    public function testFromWKTWithEmptyGeometryCollection()
+    {
+        /**
+         * @var GeometryCollection
+         */
+        $geometryCollection = GeometryCollection::fromWKT('GEOMETRYCOLLECTION()');
+        $this->assertInstanceOf(GeometryCollection::class, $geometryCollection);
+
+        $this->assertEquals(0, $geometryCollection->count());
+    }
+
+    public function testToWKTWithEmptyGeometryCollection()
+    {
+        $this->assertEquals('GEOMETRYCOLLECTION()', (new GeometryCollection([]))->toWKT());
+    }
+
     public function testInvalidArgumentExceptionNotArrayGeometries()
     {
         $this->assertException(

--- a/tests/Unit/Types/GeometryCollectionTest.php
+++ b/tests/Unit/Types/GeometryCollectionTest.php
@@ -35,7 +35,10 @@ class GeometryCollectionTest extends BaseTestCase
 
     public function testInvalidArgumentExceptionNotArrayGeometries()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\GeometryCollection must be a collection of Grimzy\LaravelMysqlSpatial\Types\GeometryInterface'
+        );
         $geometrycollection = new GeometryCollection([
             $this->getPoint(),
             1,
@@ -85,7 +88,10 @@ class GeometryCollectionTest extends BaseTestCase
         $this->assertEquals($point100, $geometryCollection[100]);
 
         // assert invalid
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\GeometryCollection must be a collection of Grimzy\LaravelMysqlSpatial\Types\GeometryInterface'
+        );
         $geometryCollection[] = 1;
     }
 

--- a/tests/Unit/Types/GeometryTest.php
+++ b/tests/Unit/Types/GeometryTest.php
@@ -32,7 +32,10 @@ class GeometryTest extends BaseTestCase
         $this->assertEquals(MultiLineString::class, Geometry::getWKTClass('MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4))'));
         $this->assertEquals(MultiPolygon::class, Geometry::getWKTClass('MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0),(1 1,2 1,2 2,1 2,1 1)), ((-1 -1,-1 -2,-2 -2,-2 -1,-1 -1)))'));
         $this->assertEquals(GeometryCollection::class, Geometry::getWKTClass('GEOMETRYCOLLECTION(POINT(2 3),LINESTRING(2 3,3 4))'));
-        $this->assertException(UnknownWKTTypeException::class);
+        $this->assertException(
+            UnknownWKTTypeException::class,
+            'Type was TRIANGLE'
+        );
         Geometry::getWKTClass('TRIANGLE((0 0, 0 9, 9 0, 0 0))');
     }
 

--- a/tests/Unit/Types/MultiLineStringTest.php
+++ b/tests/Unit/Types/MultiLineStringTest.php
@@ -59,13 +59,19 @@ class MultiLineStringTest extends BaseTestCase
 
     public function testInvalidArgumentExceptionAtLeastOneEntry()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiLineString must contain at least 1 entry'
+        );
         $multilinestring = new MultiLineString([]);
     }
 
     public function testInvalidArgumentExceptionNotArrayOfLineString()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiLineString must be a collection of Grimzy\LaravelMysqlSpatial\Types\LineString'
+        );
         $multilinestring = new MultiLineString([
             new LineString([new Point(0, 0), new Point(1, 1)]),
             new Point(0, 1),
@@ -98,7 +104,10 @@ class MultiLineStringTest extends BaseTestCase
         $this->assertEquals($linestring2, $multilinestring[2]);
 
         // assert invalid
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiLineString must be a collection of Grimzy\LaravelMysqlSpatial\Types\LineString'
+        );
         $multilinestring[] = 1;
     }
 }

--- a/tests/Unit/Types/MultiPointTest.php
+++ b/tests/Unit/Types/MultiPointTest.php
@@ -58,13 +58,19 @@ class MultiPointTest extends BaseTestCase
 
     public function testInvalidArgumentExceptionAtLeastOneEntry()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPoint must contain at least 1 entry'
+        );
         $multipoint = new MultiPoint([]);
     }
 
     public function testInvalidArgumentExceptionNotArrayOfLineString()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPoint must be a collection of Grimzy\LaravelMysqlSpatial\Types\Point'
+        );
         $multipoint = new MultiPoint([
             new Point(0, 0),
             1,
@@ -87,7 +93,10 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals($point2, $multipoint[2]);
 
         // assert invalid
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPoint must be a collection of Grimzy\LaravelMysqlSpatial\Types\Point'
+        );
         $multipoint[] = 1;
     }
 
@@ -132,7 +141,10 @@ class MultiPointTest extends BaseTestCase
         $this->assertEquals($point2, $multipoint[1]);
         $this->assertEquals($point3, $multipoint[2]);
 
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            '$index is greater than the size of the array'
+        );
         $multipoint->insertPoint(100, new Point(100, 100));
     }
 }

--- a/tests/Unit/Types/MultiPolygonTest.php
+++ b/tests/Unit/Types/MultiPolygonTest.php
@@ -75,7 +75,16 @@ class MultiPolygonTest extends BaseTestCase
         $this->assertSame('{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,1],[0,0]],[[10,10],[20,10],[20,20],[10,20],[10,10]]],[[[100,100],[200,100],[200,200],[100,200],[100,100]]]]}', json_encode($this->getMultiPolygon()));
     }
 
-    public function testInvalidArgumentExceptionNotArrayOfLineString()
+    public function testInvalidArgumentExceptionAtLeastOneEntry()
+    {
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPolygon must contain at least 1 entry'
+        );
+        $multipolygon = new MultiPolygon([]);
+    }
+
+    public function testInvalidArgumentExceptionNotArrayOfPolygon()
     {
         $this->assertException(
             InvalidArgumentException::class,

--- a/tests/Unit/Types/MultiPolygonTest.php
+++ b/tests/Unit/Types/MultiPolygonTest.php
@@ -77,7 +77,10 @@ class MultiPolygonTest extends BaseTestCase
 
     public function testInvalidArgumentExceptionNotArrayOfLineString()
     {
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPolygon must be a collection of Grimzy\LaravelMysqlSpatial\Types\Polygon'
+        );
         $multipolygon = new MultiPolygon([
             $this->getPolygon1(),
             $this->getLineString1(),
@@ -101,7 +104,10 @@ class MultiPolygonTest extends BaseTestCase
         $this->assertEquals($polygon2, $multipolygon[2]);
 
         // assert invalid
-        $this->assertException(InvalidArgumentException::class);
+        $this->assertException(
+            InvalidArgumentException::class,
+            'Grimzy\LaravelMysqlSpatial\Types\MultiPolygon must be a collection of Grimzy\LaravelMysqlSpatial\Types\Polygon'
+        );
         $multipolygon[] = 1;
     }
 


### PR DESCRIPTION
Closes https://github.com/grimzy/laravel-mysql-spatial/issues/95

Validation:
| Class                        | Min items     | Item Type                |
|------------------------------|---------------|--------------------------|
| `GeometryCollection`         | 0             | `GeometryInterface`      |
| (abstract) `PointCollection` | 0 (inherited) | `Point`                  |
| `LineString`                 | 2             | `Point` (inherited)      |
| `MultiPoint`                 | 1             | `Point` (inherited)      |
| `MultiLineString`            | 1             | `LineString`             |
| `Polygon`                    | 1 (inherited) | `LineString` (inherited) |
| `MultiPolygon`               | 1             | `Polygon`                |

----

Tested with:
```sql
-- Fails with message: 'Invalid GIS data provided to function st_geomfromtext.'
SET @multipt2 = ST_GeomFromText('MULTIPOINT()'); 
SET @line2a = ST_GeomFromText('LINESTRING(0 0)');
SET @line2b = ST_GeomFromText('LINESTRING()');
SET @multiline2a = ST_GeomFromText('MULTILINESTRING()');
SET @multiline2b = ST_GeomFromText('MULTILINESTRING((1 1))');
SET @poly2 = ST_GeomFromText('POLYGON()');
SET @multipoly2 = ST_GeomFromText('MULTIPOLYGON()');

-- Works:
SET @multipt1 = ST_GeomFromText('MULTIPOINT(0 0)');
SET @line1 = ST_GeomFromText('LINESTRING(0 0, 1 1)'); -- requires 2 points
SET @multiline1 = ST_GeomFromText('MULTILINESTRING((0 0, 1 1))');
SET @poly1a = ST_GeomFromText('POLYGON((0 0,10 0,10 10,0 10,0 0), (5 5,7 5,7 7,5 7, 5 5))');
SET @poly1b = ST_GeomFromText('POLYGON((0 0,10 0,10 10,0 10,0 0))');
SET @multipoly1 = ST_GeomFromText('MULTIPOLYGON(((0 0,10 0,10 10,0 10,0 0)))');
SET @geocol1a = ST_GeomFromText('GEOMETRYCOLLECTION(POINT(1 1))');
SET @geocol1b = ST_GeomFromText('GEOMETRYCOLLECTION()'); -- works while empty
```