### PR TITLE
fix: prevent wrong formatting float values by locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
   - docker
 
 before_install:
-  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=3G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - sudo /etc/init.d/mysql stop
   - make start_db V=$MYSQL_VERSION
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": ">=5.5",
         "ext-pdo": "*",
         "ext-json": "*",
+        "ext-intl": "*",
         "illuminate/database": "^5.2|^6.0",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0"

--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -2,6 +2,7 @@
 
 namespace Grimzy\LaravelMysqlSpatial\Types;
 
+use NumberFormatter;
 use GeoJson\GeoJson;
 use GeoJson\Geometry\Point as GeoJsonPoint;
 use Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException;
@@ -40,7 +41,13 @@ class Point extends Geometry
 
     public function toPair()
     {
-        return $this->getLng().' '.$this->getLat();
+        $formatter = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, -1);
+
+        $lng = $formatter->format($this->getLng());
+        $lat = $formatter->format($this->getLat());
+
+        return $lng . ' ' . $lat;
     }
 
     public static function fromPair($pair)
@@ -62,7 +69,7 @@ class Point extends Geometry
 
     public function __toString()
     {
-        return $this->getLng().' '.$this->getLat();
+        return $this->toPair();
     }
 
     /**

--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -42,7 +42,7 @@ class Point extends Geometry
     public function toPair()
     {
         $formatter = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
-        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, -1);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 12);
 
         $lng = $formatter->format($this->getLng());
         $lat = $formatter->format($this->getLat());

--- a/tests/Unit/Types/PointLocaleTest.php
+++ b/tests/Unit/Types/PointLocaleTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Grimzy\LaravelMysqlSpatial\Types\Point;
+
+class PointLocaleTest extends BaseTestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        setlocale(LC_ALL, 'pt_BR.UTF-8');
+    }
+
+    public function tearDown()
+    {
+        parent::setUp();
+
+        setlocale(LC_ALL, 'en_US.UTF-8');
+    }
+
+    
+    public function testFromWKT()
+    {
+        $point = Point::fromWKT('POINT(1 2)');
+
+        $this->assertInstanceOf(Point::class, $point);
+        $this->assertEquals(2, $point->getLat());
+        $this->assertEquals(1, $point->getLng());
+    }
+
+    public function testToWKT()
+    {
+        $point = new Point(1, 2);
+
+        $this->assertEquals('POINT(2 1)', $point->toWKT());
+    }
+
+    public function testGettersAndSetters()
+    {
+        $point = new Point(1, 2);
+        $this->assertSame(1.0, $point->getLat());
+        $this->assertSame(2.0, $point->getLng());
+
+        $point->setLat('3');
+        $point->setLng('4');
+
+        $this->assertSame(3.0, $point->getLat());
+        $this->assertSame(4.0, $point->getLng());
+    }
+
+    public function testPairLocale()
+    {
+        setlocale(LC_ALL, 'pt_BR.UTF-8');
+        $point = Point::fromPair('1.5 2');
+
+        $this->assertSame(1.5, $point->getLng());
+        $this->assertSame(2.0, $point->getLat());
+
+        $this->assertSame('1.5 2', $point->toPair());
+        setlocale(LC_ALL, "en-US.UTF-8");
+    }
+
+    public function testPair()
+    {
+        $point = Point::fromPair('1.5 2');
+
+        $this->assertSame(1.5, $point->getLng());
+        $this->assertSame(2.0, $point->getLat());
+
+        $this->assertSame('1.5 2', $point->toPair());
+    }
+
+    public function testToString()
+    {
+        $point = Point::fromString('1.3 2');
+
+        $this->assertSame(1.3, $point->getLng());
+        $this->assertSame(2.0, $point->getLat());
+
+        $this->assertEquals('1.3 2', (string) $point);
+    }
+
+    public function testFromJson()
+    {
+        $point = Point::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
+        $this->assertInstanceOf(Point::class, $point);
+        $this->assertEquals(1.2, $point->getLat());
+        $this->assertEquals(3.4, $point->getLng());
+    }
+
+    public function testInvalidGeoJsonException()
+    {
+        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        Point::fromJson('{"type": "LineString","coordinates":[[1,1],[2,2]]}');
+    }
+
+    public function testJsonSerialize()
+    {
+        $point = new Point(1.2, 3.4);
+
+        $this->assertInstanceOf(\GeoJson\Geometry\Point::class, $point->jsonSerialize());
+        $this->assertSame('{"type":"Point","coordinates":[3.4,1.2]}', json_encode($point));
+    }
+}


### PR DESCRIPTION
resolves #84
that's the right-way fix. but to avoid install ext-intl, we can just replace comma by a dot.