### PR TITLE
Let SpatialExpression implement the toWkt() method

### DIFF
--- a/src/Eloquent/SpatialExpression.php
+++ b/src/Eloquent/SpatialExpression.php
@@ -15,4 +15,9 @@ class SpatialExpression extends Expression
     {
         return $this->value->toWkt();
     }
+
+    public function toWkt()
+    {
+        return $this->value->toWkt();
+    }
 }


### PR DESCRIPTION
This avoids that most spatial query functions fail when invoked from oberver methods.

E.g.

Test setup

        $incomingMessage = new RawMessage();
        $incomingMessage->beacon_id = $boat->beacon_id;
        $incomingMessage->boat_id = $boat->id;
        $incomingMessage->timestamp = CarbonImmutable::now();
        $incomingMessage->type = MessageType::LOCATION_UPDATE();
        $incomingMessage->location_precision = 5;
        $incomingMessage->coordinates = new Point(5, 5);
        $incomingMessage->save();

Observer on RawMessage created() event

        $weatherAlerts = WeatherAlert::ongoing()
            ->atLocation($rawMessage->coordinates)
            ->get();

Crash

    Error : Call to undefined method Grimzy\LaravelMysqlSpatial\Eloquent\SpatialExpression::toWkt()

Basically, in the observer, when doing `->atLocation($rawMessage->coordinates)`, the coordinates getter returns a SpatialExpression and not the original Point

This PR simply implements the toWkt method, in a harmless and perfectly safe way as it does the same thing as the existing getSpatialValue method

Fixes #115 