### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "php": ">=5.5.9",
         "ext-pdo": "*",
         "ext-json": "*",
-        "illuminate/database": "^5.2|^6.0|^7.0",
+        "illuminate/database": "^8.0",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.7",
         "mockery/mockery": "^0.9.9",
-        "laravel/laravel": "^5.2|^6.0|^7.0",
+        "laravel/laravel": "^8.0",
         "doctrine/dbal": "^2.5",
         "laravel/browser-kit-testing": "^2.0",
         "php-coveralls/php-coveralls": "^2.0"

--- a/src/Eloquent/BaseBuilder.php
+++ b/src/Eloquent/BaseBuilder.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class BaseBuilder extends QueryBuilder
 {
-    protected function cleanBindings(array $bindings)
+    public function cleanBindings(array $bindings)
     {
         $spatialBindings = [];
         foreach ($bindings as &$binding) {


### PR DESCRIPTION
This contains breaking changes (`QueryBuilder::cleanBindings` is now public), so needs to be released as a new **major** version (4.0).