### PR TITLE
Add toGeoJson()

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ $point = new Point(40.7484404, -73.9878441);
 json_encode($point); // or $point->toJson();
 
 // {
+//    "type": "Point",
+//    "coordinates": [
+//     -73.9878441,
+//     40.7484404
+//    ]
+// }
+
+$point->toGeoJson();
+
+// {
 //   "type": "Feature",
 //   "properties": {},
 //   "geometry": {

--- a/src/Types/Geometry.php
+++ b/src/Types/Geometry.php
@@ -3,6 +3,7 @@
 namespace Grimzy\LaravelMysqlSpatial\Types;
 
 use GeoIO\WKB\Parser\Parser;
+use GeoJson\Feature\Feature;
 use GeoJson\GeoJson;
 use Grimzy\LaravelMysqlSpatial\Exceptions\UnknownWKTTypeException;
 use Illuminate\Contracts\Support\Jsonable;
@@ -108,7 +109,7 @@ abstract class Geometry implements GeometryInterface, Jsonable, \JsonSerializabl
             $geoJson = $geoJson->getGeometry();
         }
 
-        $type = '\Grimzy\LaravelMysqlSpatial\Types\\'.$geoJson->getType();
+        $type = '\Grimzy\LaravelMysqlSpatial\Types\\' . $geoJson->getType();
 
         return $type::fromJson($geoJson);
     }
@@ -116,5 +117,12 @@ abstract class Geometry implements GeometryInterface, Jsonable, \JsonSerializabl
     public function toJson($options = 0)
     {
         return json_encode($this, $options);
+    }
+
+    public function toGeoJson($properties = [], $options = 0)
+    {
+        $feature = new Feature($this->jsonSerialize(), $properties);
+
+        return json_encode($feature->jsonSerialize(), $options);
     }
 }

--- a/src/Types/Geometry.php
+++ b/src/Types/Geometry.php
@@ -109,7 +109,7 @@ abstract class Geometry implements GeometryInterface, Jsonable, \JsonSerializabl
             $geoJson = $geoJson->getGeometry();
         }
 
-        $type = '\Grimzy\LaravelMysqlSpatial\Types\\' . $geoJson->getType();
+        $type = '\Grimzy\LaravelMysqlSpatial\Types\\'.$geoJson->getType();
 
         return $type::fromJson($geoJson);
     }

--- a/src/Types/GeometryCollection.php
+++ b/src/Types/GeometryCollection.php
@@ -156,6 +156,15 @@ class GeometryCollection extends Geometry implements IteratorAggregate, ArrayAcc
         return new \GeoJson\Geometry\GeometryCollection($geometries);
     }
 
+    public function toGeoJson($properties = [], $options = 0)
+    {
+        if (static::class !== GeometryCollection::class) {
+            return parent::toGeoJson();
+        }
+
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
     /**
      * Checks whether the items are valid to create this collection.
      *

--- a/tests/Unit/Types/GeometryCollectionTest.php
+++ b/tests/Unit/Types/GeometryCollectionTest.php
@@ -33,6 +33,12 @@ class GeometryCollectionTest extends BaseTestCase
         $this->assertSame('{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[0,0],[1,0],[1,1],[0,1],[0,0]]},{"type":"Point","coordinates":[200,100]}]}', json_encode($this->getGeometryCollection()->jsonSerialize()));
     }
 
+    public function testToGeoJson()
+    {
+        $this->assertJson($this->getGeometryCollection()->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"GeometryCollection","geometries":[{"type":"LineString","coordinates":[[0,0],[1,0],[1,1],[0,1],[0,0]]},{"type":"Point","coordinates":[200,100]}]}', $this->getGeometryCollection()->toGeoJson());
+    }
+
     public function testCanCreateEmptyGeometryCollection()
     {
         $geometryCollection = new GeometryCollection([]);

--- a/tests/Unit/Types/LineStringTest.php
+++ b/tests/Unit/Types/LineStringTest.php
@@ -59,4 +59,12 @@ class LineStringTest extends BaseTestCase
         $this->assertInstanceOf(\GeoJson\Geometry\LineString::class, $lineString->jsonSerialize());
         $this->assertSame('{"type":"LineString","coordinates":[[0,0],[1,1],[2,2]]}', json_encode($lineString));
     }
+
+    public function testToGeoJson()
+    {
+        $lineString = new LineString($this->points);
+
+        $this->assertJson($lineString->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"LineString","coordinates":[[0,0],[1,1],[2,2]]},"properties":{}}', $lineString->toGeoJson());
+    }
 }

--- a/tests/Unit/Types/MultiLineStringTest.php
+++ b/tests/Unit/Types/MultiLineStringTest.php
@@ -60,6 +60,14 @@ class MultiLineStringTest extends BaseTestCase
         $this->assertSame('{"type":"MultiLineString","coordinates":[[[0,0],[1,1],[1,2]],[[2,3],[3,2],[5,4]]]}', json_encode($multilinestring));
     }
 
+    public function testToGeoJson()
+    {
+        $multilinestring = MultiLineString::fromWKT('MULTILINESTRING((0 0,1 1,1 2),(2 3,3 2,5 4))');
+
+        $this->assertJson($multilinestring->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"MultiLineString","coordinates":[[[0,0],[1,1],[1,2]],[[2,3],[3,2],[5,4]]]},"properties":{}}', $multilinestring->toGeoJson());
+    }
+
     public function testInvalidArgumentExceptionAtLeastOneEntry()
     {
         $this->assertException(

--- a/tests/Unit/Types/MultiPointTest.php
+++ b/tests/Unit/Types/MultiPointTest.php
@@ -59,6 +59,16 @@ class MultiPointTest extends BaseTestCase
         $this->assertSame('{"type":"MultiPoint","coordinates":[[0,0],[1,0],[1,1]]}', json_encode($multipoint));
     }
 
+    public function testToGeoJson()
+    {
+        $collection = [new Point(0, 0), new Point(0, 1), new Point(1, 1)];
+
+        $multipoint = new MultiPoint($collection);
+
+        $this->assertJson($multipoint->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"MultiPoint","coordinates":[[0,0],[1,0],[1,1]]},"properties":{}}', $multipoint->toGeoJson());
+    }
+
     public function testInvalidArgumentExceptionAtLeastOneEntry()
     {
         $this->assertException(

--- a/tests/Unit/Types/MultiPolygonTest.php
+++ b/tests/Unit/Types/MultiPolygonTest.php
@@ -183,4 +183,11 @@ class MultiPolygonTest extends BaseTestCase
             ]),
         ]);
     }
+
+    public function testToGeoJson()
+    {
+        $multiPolygon = MultiPolygon::fromJson('{"type":"MultiPolygon","coordinates":[[[[1,1],[1,2],[2,2],[2,1],[1,1]]],[[[0,0],[0,1],[1,1],[1,0],[0,0]]]]}');
+        $this->assertJson($multiPolygon->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":[[[[1,1],[1,2],[2,2],[2,1],[1,1]]],[[[0,0],[0,1],[1,1],[1,0],[0,0]]]]},"properties":{}}', $multiPolygon->toGeoJson());
+    }
 }

--- a/tests/Unit/Types/PointTest.php
+++ b/tests/Unit/Types/PointTest.php
@@ -83,4 +83,23 @@ class PointTest extends BaseTestCase
         $this->assertInstanceOf(\GeoJson\Geometry\Point::class, $point->jsonSerialize());
         $this->assertSame('{"type":"Point","coordinates":[3.4,1.2]}', json_encode($point));
     }
+
+    public function testToGeoJson()
+    {
+        $point = new Point(1.2, 3.4);
+
+        $this->assertJson($point->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"Point","coordinates":[3.4,1.2]},"properties":{}}
+        ', $point->toGeoJson());
+    }
+
+    public function testToGeoJsonWithProperties()
+    {
+        $point = new Point(1.2, 3.4);
+
+        $properties = ['key' => 'value', 'key_1' => true, 'key_2' => 0, 'key_3' => null, 'key_4' => [1, 2, 'a']];
+
+        $this->assertJson($point->toGeoJson($properties));
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"Point","coordinates":[3.4,1.2]},"properties":{"key":"value","key_1":true,"key_2":0,"key_3":null,"key_4":[1,2,"a"]}}', $point->toGeoJson($properties));
+    }
 }

--- a/tests/Unit/Types/PolygonTest.php
+++ b/tests/Unit/Types/PolygonTest.php
@@ -71,4 +71,10 @@ class PolygonTest extends BaseTestCase
             json_encode($this->polygon)
         );
     }
+
+    public function testToGeoJson()
+    {
+        $this->assertJson($this->polygon->toGeoJson());
+        $this->assertJsonStringEqualsJsonString('{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]},"properties":{}}', $this->polygon->toGeoJson());
+    }
 }


### PR DESCRIPTION
First of all, thank you so much for this great package!

As suggested in #113 , it's not yet possible to generate normalized GeoJSON for a geometry. This PR adds this functionality including an updated README and tests. Properties in GeoJSON are also supported.

Contrary to `Geometry::toJson()`, the new `Geometry::toGeoJson()` returns a string instead of a JSON-able representation. I'm not sure if this is a good idea (because `toGeoJson` implies it should return JSON) or if it should behave like `toJson()` (for consistency). What do you think?

Let me know if you'd like me to make any changes!