### PR TITLE
Allow setting WKT options or disabling WKT options entirely.

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -7,6 +7,14 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class Builder extends EloquentBuilder
 {
+    /**
+     * The options to be passed to the ST_GeomFromText() function.
+     * If set to false, the options argument will not be passed.
+     *
+     * @var string
+     */
+    protected $wktOptions = 'axis-order=long-lat';
+
     public function update(array $values)
     {
         foreach ($values as $key => &$value) {
@@ -20,6 +28,19 @@ class Builder extends EloquentBuilder
 
     protected function asWKT(GeometryInterface $geometry)
     {
-        return new SpatialExpression($geometry);
+        return (new SpatialExpression($geometry))->withWktOptions($this->wktOptions);
+    }
+
+    /**
+     * Set the WKT options.
+     *
+     * @param  string $wktOptions
+     * @return self
+     */
+    public function withWktOptions($wktOptions)
+    {
+        $this->wktOptions = $wktOptions;
+
+        return $this;
     }
 }

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -34,7 +34,8 @@ class Builder extends EloquentBuilder
     /**
      * Set the WKT options.
      *
-     * @param  string $wktOptions
+     * @param string $wktOptions
+     *
      * @return self
      */
     public function withWktOptions($wktOptions)

--- a/src/Eloquent/SpatialExpression.php
+++ b/src/Eloquent/SpatialExpression.php
@@ -6,9 +6,19 @@ use Illuminate\Database\Query\Expression;
 
 class SpatialExpression extends Expression
 {
+    /**
+     * The options to be passed to the ST_GeomFromText() function.
+     * If set to false, the options argument will not be passed.
+     *
+     * @var string
+     */
+    protected $wktOptions = 'axis-order=long-lat';
+
     public function getValue()
     {
-        return "ST_GeomFromText(?, ?, 'axis-order=long-lat')";
+        $thirdArgument = $this->wktOptions ? ", '$this->wktOptions'" : '';
+
+        return "ST_GeomFromText(?, ?$thirdArgument)";
     }
 
     public function getSpatialValue()
@@ -19,5 +29,18 @@ class SpatialExpression extends Expression
     public function getSrid()
     {
         return $this->value->getSrid();
+    }
+
+    /**
+     * Set the WKT options.
+     *
+     * @param  string $wktOptions
+     * @return self
+     */
+    public function withWktOptions($wktOptions)
+    {
+        $this->wktOptions = $wktOptions;
+
+        return $this;
     }
 }

--- a/src/Eloquent/SpatialExpression.php
+++ b/src/Eloquent/SpatialExpression.php
@@ -34,7 +34,8 @@ class SpatialExpression extends Expression
     /**
      * Set the WKT options.
      *
-     * @param  string $wktOptions
+     * @param string $wktOptions
+     *
      * @return self
      */
     public function withWktOptions($wktOptions)


### PR DESCRIPTION
Unlike MySQL, the WKT-input spatial analysis functions in **MariaDB** like `ST_GeomFromText` and `ST_DISTANCE` do not take an options parameter: https://mariadb.com/kb/en/st_geomfromtext/

If I understand correctly, we need to pass "`axis-order=long-lat`" because otherwise some versions of MySQL will interpret coordinate pairs as lat-long. For MariaDB, this is not necessary because MariaDB reads WKT values as long-lat by default.

In its current state, using this package with MariaDB will throw the following exception when trying to insert or update values for a spatial column, because we force the third options parameter in `ST_GeomFromText`:

```
Syntax error or access violation: 1582 Incorrect parameter count in the call to native function 'ST_GeomFromText'
```

This is because the MariaDB function expects at most two arguments: https://github.com/MariaDB/server/blob/cf87f3e08c10dd7a944447ddee93fbc3827e6570/sql/item_geofunc.cc#L2993

This PR adds the option to set a `$wktOptions` property on the model that will overwrite the default options "axis-order=long-lat". It can be set to false to remove the options parameter entirely, which fixes the errors when using MariaDB.

Additionally, it adds flexibility for users that may want or need to change the WKT options for whichever reason.

This is completely backwards-compatible, because if `$wktOptions` is not set, it will default to "axis-order=long-lat".