### PR TITLE
Support Laravel 8 / MySQL 5.7 (v5.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: php
 
 php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
+  - '7.3'
+  - '7.4'
 
 env:
   - MYSQL_VERSION=5.7
@@ -33,7 +30,5 @@ before_script:
 
 script: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
-after_script:
-  - php vendor/bin/coveralls -v
-  - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
+after_script: ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Please check the documentation for your MySQL version. MySQL's Extension for Spa
 **Versions**
 
 - `1.x.x`: MySQL 5.6 (also supports MySQL 5.5 but not all spatial analysis functions)
-- `2.x.x`: MySQL 5.7 and 8.0
+- `2.x.x`: MySQL 5.7 and 8.0 (Laravel version < 8.0)
+- `3.x.x`: MySQL 8.0 with SRID support (Laravel version < 8.0)
+- `4.x.x`: MySQL 8.0 with SRID support (Laravel 8)
+- **`5.x.x`: MySQL 5.7 and 8.0 (Laravel 8) [Current branch]**
 
 This package also works with MariaDB. Please refer to the [MySQL/MariaDB Spatial Support Matrix](https://mariadb.com/kb/en/library/mysqlmariadb-spatial-support-matrix/) for compatibility.
 
@@ -22,7 +25,10 @@ This package also works with MariaDB. Please refer to the [MySQL/MariaDB Spatial
 Add the package using composer:
 
 ```shell
-composer require grimzy/laravel-mysql-spatial
+$ composer require grimzy/laravel-mysql-spatial:^5.0
+
+# or for Laravel version < 8.0
+$ composer require grimzy/laravel-mysql-spatial:^2.0
 ```
 
 For MySQL 5.6 and 5.5:

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,19 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.3",
         "ext-pdo": "*",
         "ext-json": "*",
-        "illuminate/database": "^5.2|^6.0|^7.0",
+        "illuminate/database": "^8.0",
         "geo-io/wkb-parser": "^1.0",
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8|~5.7",
-        "mockery/mockery": "^0.9.9",
-        "laravel/laravel": "^5.2|^6.0|^7.0",
+        "laravel/laravel": "^8.0",
         "doctrine/dbal": "^2.5",
         "laravel/browser-kit-testing": "^2.0",
-        "php-coveralls/php-coveralls": "^2.0"
+        "mockery/mockery": "^0.9.9"
     },
     "autoload": {
         "psr-4": {
@@ -43,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "5.0.x-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "jmikola/geojson": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8|~5.7",
+        "phpunit/phpunit": "~6.5",
         "laravel/laravel": "^8.0",
         "doctrine/dbal": "^2.5",
         "laravel/browser-kit-testing": "^2.0",
-        "mockery/mockery": "^0.9.9"
+        "mockery/mockery": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Eloquent/BaseBuilder.php
+++ b/src/Eloquent/BaseBuilder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Grimzy\LaravelMysqlSpatial\Eloquent;
 
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/src/Eloquent/BaseBuilder.php
+++ b/src/Eloquent/BaseBuilder.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Grimzy\LaravelMysqlSpatial\Eloquent;
 
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class BaseBuilder extends QueryBuilder
 {
-    protected function cleanBindings(array $bindings)
+    public function cleanBindings(array $bindings)
     {
         $bindings = array_map(function ($binding) {
             return $binding instanceof SpatialExpression ? $binding->getSpatialValue() : $binding;

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -1,6 +1,8 @@
 <?php
 
-abstract class BaseTestCase extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTestCase extends TestCase
 {
     public function tearDown()
     {

--- a/tests/Unit/Eloquent/BuilderTest.php
+++ b/tests/Unit/Eloquent/BuilderTest.php
@@ -41,9 +41,12 @@ class BuilderTest extends BaseTestCase
         $this->queryBuilder
             ->shouldReceive('update')
             ->with(['point' => new SpatialExpression($point)])
-            ->once();
+            ->once()
+            ->andReturn(1);
 
-        $this->builder->update(['point' => $point]);
+        $result = $this->builder->update(['point' => $point]);
+
+        $this->assertSame(1, $result);
     }
 
     public function testUpdateLinestring()
@@ -53,9 +56,12 @@ class BuilderTest extends BaseTestCase
         $this->queryBuilder
             ->shouldReceive('update')
             ->with(['linestring' => new SpatialExpression($linestring)])
-            ->once();
+            ->once()
+            ->andReturn(1);
 
-        $this->builder->update(['linestring' => $linestring]);
+        $result = $this->builder->update(['linestring' => $linestring]);
+
+        $this->assertSame(1, $result);
     }
 
     public function testUpdatePolygon()
@@ -68,9 +74,12 @@ class BuilderTest extends BaseTestCase
         $this->queryBuilder
             ->shouldReceive('update')
             ->with(['polygon' => new SpatialExpression($polygon)])
-            ->once();
+            ->once()
+            ->andReturn(1);
 
-        $this->builder->update(['polygon' => $polygon]);
+        $result = $this->builder->update(['polygon' => $polygon]);
+
+        $this->assertSame(1, $result);
     }
 }
 

--- a/tests/Unit/Eloquent/SpatialTraitTest.php
+++ b/tests/Unit/Eloquent/SpatialTraitTest.php
@@ -5,9 +5,12 @@ use Grimzy\LaravelMysqlSpatial\MysqlConnection;
 use Grimzy\LaravelMysqlSpatial\Types\Point;
 use Illuminate\Database\Eloquent\Model;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class SpatialTraitTest extends BaseTestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var TestModel
      */
@@ -217,7 +220,10 @@ class SpatialTraitTest extends BaseTestCase
     public function testSpatialFieldsNotDefinedException()
     {
         $model = new TestNoSpatialModel();
-        $this->setExpectedException(SpatialFieldsNotDefinedException::class);
+        $this->assertException(
+            SpatialFieldsNotDefinedException::class,
+            'TestNoSpatialModel has to define $spatialFields'
+        );
         $model->getSpatialFields();
     }
 

--- a/tests/Unit/Eloquent/SpatialTraitTest.php
+++ b/tests/Unit/Eloquent/SpatialTraitTest.php
@@ -4,8 +4,8 @@ use Grimzy\LaravelMysqlSpatial\Exceptions\SpatialFieldsNotDefinedException;
 use Grimzy\LaravelMysqlSpatial\MysqlConnection;
 use Grimzy\LaravelMysqlSpatial\Types\Point;
 use Illuminate\Database\Eloquent\Model;
-use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery as m;
 
 class SpatialTraitTest extends BaseTestCase
 {

--- a/tests/Unit/MysqlConnectionTest.php
+++ b/tests/Unit/MysqlConnectionTest.php
@@ -2,9 +2,10 @@
 
 use Grimzy\LaravelMysqlSpatial\MysqlConnection;
 use Grimzy\LaravelMysqlSpatial\Schema\Builder;
+use PHPUnit\Framework\TestCase;
 use Stubs\PDOStub;
 
-class MysqlConnectionTest extends PHPUnit_Framework_TestCase
+class MysqlConnectionTest extends TestCase
 {
     private $mysqlConnection;
 

--- a/tests/Unit/Schema/BlueprintTest.php
+++ b/tests/Unit/Schema/BlueprintTest.php
@@ -4,6 +4,7 @@ namespace Schema;
 
 use BaseTestCase;
 use Grimzy\LaravelMysqlSpatial\Schema\Blueprint;
+use Illuminate\Database\Schema\ColumnDefinition;
 use Mockery;
 
 class BlueprintTest extends BaseTestCase
@@ -20,81 +21,153 @@ class BlueprintTest extends BaseTestCase
 
     public function testGeometry()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'geometry',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('geometry', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->geometry('col');
+        $result = $this->blueprint->geometry('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testPoint()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'point',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('point', 'col', ['srid' => null])
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->point('col');
+        $result = $this->blueprint->point('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testLinestring()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'linestring',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('linestring', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->linestring('col');
+        $result = $this->blueprint->linestring('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testPolygon()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'polygon',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('polygon', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->polygon('col');
+        $result = $this->blueprint->polygon('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testMultiPoint()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'multipoint',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('multipoint', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->multipoint('col');
+        $result = $this->blueprint->multipoint('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testMultiLineString()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'multilinestring',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('multilinestring', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->multilinestring('col');
+        $result = $this->blueprint->multilinestring('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
-    public function testMulltiPolygon()
+    public function testMultiPolygon()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'multipolygon',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('multipolygon', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->multipolygon('col');
+        $result = $this->blueprint->multipolygon('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 
     public function testGeometryCollection()
     {
+        $expectedCol = new ColumnDefinition([
+            'type' => 'geometrycollection',
+            'name' => 'col',
+            'srid' => null,
+        ]);
+
         $this->blueprint
             ->shouldReceive('addColumn')
             ->with('geometrycollection', 'col')
-            ->once();
+            ->once()
+            ->andReturn($expectedCol);
 
-        $this->blueprint->geometrycollection('col');
+        $result = $this->blueprint->geometrycollection('col');
+
+        $this->assertSame($expectedCol, $result);
     }
 }

--- a/tests/Unit/Types/GeometryCollectionTest.php
+++ b/tests/Unit/Types/GeometryCollectionTest.php
@@ -129,7 +129,10 @@ class GeometryCollectionTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            sprintf('Expected %s, got %s', GeoJson\Feature\FeatureCollection::class, GeoJson\Geometry\Point::class)
+        );
         GeometryCollection::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 

--- a/tests/Unit/Types/LineStringTest.php
+++ b/tests/Unit/Types/LineStringTest.php
@@ -45,7 +45,10 @@ class LineStringTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            sprintf('Expected %s, got %s', \GeoJson\Geometry\LineString::class, GeoJson\Geometry\Point::class)
+        );
         LineString::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 

--- a/tests/Unit/Types/MultiLineStringTest.php
+++ b/tests/Unit/Types/MultiLineStringTest.php
@@ -45,7 +45,10 @@ class MultiLineStringTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            sprintf('Expected %s, got %s', GeoJson\Geometry\MultiLineString::class, GeoJson\Geometry\Point::class)
+        );
         MultiLineString::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 

--- a/tests/Unit/Types/MultiPointTest.php
+++ b/tests/Unit/Types/MultiPointTest.php
@@ -42,7 +42,10 @@ class MultiPointTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            sprintf('Expected %s, got %s', GeoJson\Geometry\MultiPoint::class, GeoJson\Geometry\Point::class)
+        );
         MultiPoint::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 

--- a/tests/Unit/Types/MultiPolygonTest.php
+++ b/tests/Unit/Types/MultiPolygonTest.php
@@ -65,7 +65,10 @@ class MultiPolygonTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            sprintf('Expected %s, got %s', GeoJson\Geometry\MultiPolygon::class, GeoJson\Geometry\Point::class)
+        );
         MultiPolygon::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 

--- a/tests/Unit/Types/PointTest.php
+++ b/tests/Unit/Types/PointTest.php
@@ -63,7 +63,10 @@ class PointTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            'Expected GeoJson\Geometry\Point, got GeoJson\Geometry\LineString'
+        );
         Point::fromJson('{"type": "LineString","coordinates":[[1,1],[2,2]]}');
     }
 

--- a/tests/Unit/Types/PolygonTest.php
+++ b/tests/Unit/Types/PolygonTest.php
@@ -56,7 +56,10 @@ class PolygonTest extends BaseTestCase
 
     public function testInvalidGeoJsonException()
     {
-        $this->setExpectedException(\Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class);
+        $this->assertException(
+            \Grimzy\LaravelMysqlSpatial\Exceptions\InvalidGeoJsonException::class,
+            'Expected GeoJson\Geometry\Polygon, got GeoJson\Geometry\Point'
+        );
         Polygon::fromJson('{"type":"Point","coordinates":[3.4,1.2]}');
     }
 


### PR DESCRIPTION
Breaking change: `QueryBuilder::cleanBindings()` is now `public`. This PR needs to be released as a new major version: `v5.0.0`.

- Adds support for Laravel 8 with MySQL 5.7
- Update build to test Laravel 8
- Fixed tests

Closes #151 #155.