### PR TITLE
Fixing connection prefix bug

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -17,6 +17,10 @@ class Builder extends MySqlBuilder
      */
     protected function createBlueprint($table, Closure $callback = null)
     {
-        return new Blueprint($table, $callback);
+        $prefix = $this->connection->getConfig('prefix_indexes')
+                    ? $this->connection->getConfig('prefix')
+                   : '';
+
+        return new Blueprint($table, $callback, $prefix);
     }
 }


### PR DESCRIPTION
The package's overloading of the `Blueprint` object pummels defined prefixes for the configured connection.  This causes migrations to not respect table and index prefix.

Reference https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Schema/Builder.php#L347