### PR TITLE
fixing an error in the SpatialTrait

### DIFF
--- a/src/Eloquent/SpatialTrait.php
+++ b/src/Eloquent/SpatialTrait.php
@@ -149,7 +149,7 @@ trait SpatialTrait
 
         $query = $this->scopeDistance($query, $geometryColumn, $geometry, $distance);
 
-        $query->whereRaw("st_distance(`$geometryColumn`, ST_GeomFromText(?, ?, 'axis-order=long-lat')) != 0", [
+        $query->whereRaw("st_distance(`$geometryColumn`, ST_GeomFromText(?, ?, 'axis-order=long-lat')) > 0.1", [
             $geometry->toWkt(),
             $geometry->getSrid(),
         ]);
@@ -192,7 +192,7 @@ trait SpatialTrait
 
         $query = $this->scopeDistanceSphere($query, $geometryColumn, $geometry, $distance);
 
-        $query->whereRaw("st_distance_sphere($geometryColumn, ST_GeomFromText(?, ?, 'axis-order=long-lat')) != 0", [
+        $query->whereRaw("st_distance_sphere($geometryColumn, ST_GeomFromText(?, ?, 'axis-order=long-lat')) > 0.1", [
             $geometry->toWkt(),
             $geometry->getSrid(),
         ]);


### PR DESCRIPTION
in order to exclude self from the distance calculation you were checking distance not be 0 but after trying it in production i found out that the SGBD can return a small number ex : 3e-17 to represent the distance to self so i fixed that. 
