### PR TITLE
Add ReturnTypeWillChange to suppress PHP Warning

### DIFF
--- a/src/Types/Point.php
+++ b/src/Types/Point.php
@@ -92,6 +92,7 @@ class Point extends Geometry
      *
      * @return \GeoJson\Geometry\Point
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return new GeoJsonPoint([$this->getLng(), $this->getLat()]);


### PR DESCRIPTION
Right now this lib throws:

> Return type of Grimzy\LaravelMysqlSpatial\Types\Point::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in xxx/vendor/grimzy/laravel-mysql-spatial/src/Types/Point.php on line 95

Fixes #182