### PR TITLE
add missing docblock @method in SpacialTrait

### DIFF
--- a/src/Eloquent/SpatialTrait.php
+++ b/src/Eloquent/SpatialTrait.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
  *
  * @method static distance($geometryColumn, $geometry, $distance)
  * @method static distanceExcludingSelf($geometryColumn, $geometry, $distance)
+ * @method static distanceValue($geometryColumn, $geometry)
  * @method static distanceSphere($geometryColumn, $geometry, $distance)
  * @method static distanceSphereExcludingSelf($geometryColumn, $geometry, $distance)
  * @method static comparison($geometryColumn, $geometry, $relationship)


### PR DESCRIPTION
Adds missing docblock definition for a scope method.